### PR TITLE
update(bootstrap): use docker as container runtime

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -10,14 +10,15 @@ remote_user: root
 # Machine Configuration #
 #########################
 
-# The default base image for the VMs. We have a dedicated variable here since it is static.
-# If you need to match a given kernel with a specific base image then change it in the machine entry.
-defaultBaseImage: "aldokcl/dronet:ignite-ubuntu-22.04-amd64"
+# The default base rootfs for the VMs. We have a dedicated variable here since it is static.
+# If you need to match a given kernel with a specific base rootfs then change it in the machine entry.
+defaultBaserootfs: "aldokcl/dronet:ignite-ubuntu-22.04-amd64"
+
 
 # Each machine entry requires the following fields
-# name: the name givent to the vm;
-# kernel: reference to an oci image containing a kernel;
-# image: reference to an oci image used as base image for the vm.
+# name: the name given to the vm;
+# kernel: reference to an OCI image containing a kernel;
+# rootfs: reference to an OCI image used as base rootfs for the vm.
 machines:
   - {name: "5.8.18",kernel: "docker.io/aldokcl/dronet:5.8.18-amd64", image: "{{ defaultBaseImage }}"}
   - {name: "5.9.16",kernel: "docker.io/aldokcl/dronet:5.9.16-amd64", image: "{{ defaultBaseImage }}"}

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Create virtual machines
   shell: |
-    ignite run --config "./roles/bootstrap/files/{{ item.name }}.yaml"
+    ignite run --config "./roles/bootstrap/files/{{ item.name }}.yaml" --runtime docker
   loop: "{{ machines }}"
   become: yes
 

--- a/roles/bootstrap/templates/ignite-vm.yaml.j2
+++ b/roles/bootstrap/templates/ignite-vm.yaml.j2
@@ -14,9 +14,9 @@ spec:
   image:
     # Required, what OCI image to use as the VM's rootfs
     # For example: weaveworks/ignite-ubuntu:latest
-    oci: {{ item.image }}
+    oci: {{ item.rootfs }}
   kernel:
-    # Required, what OCI image to get the kernel binary (and optionally modules) from
+    # Required, what OCI rootfs to get the kernel binary (and optionally modules) from
     # Default: weaveworks/ignite-kernel:5.10.51
     oci:  {{ item.kernel}}
 


### PR DESCRIPTION
Use `docker` as container runtime when creating mivroVS with ignite.