### PR TITLE
chore(ci): do not fail when playbook fails 

### DIFF
--- a/.github/workflows/kernel_tests.yaml
+++ b/.github/workflows/kernel_tests.yaml
@@ -24,10 +24,17 @@ jobs:
     
       - name: Run kernels tests
         run: |
-          ansible-playbook master-playbook.yml
+          ansible-playbook master-playbook.yml || :
+          
+      - name: Tar output files
+        run: tar -cvf ansible_output.tar ~/ansible_output
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ansible_output_${{matrix.architecture}}
+          path: ansible_output.tar
           
       - name: Cleanup
-        if: always()
         run: |
           ansible-playbook clean-up.yml
       


### PR DESCRIPTION
(ie: when at least 1 kernel test fails).

Moreover, properly upload generated output files.