### PR TITLE
chore: use branches keyword.

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,8 @@ name: Deploy Github Pages
 on:
   workflow_run:
     workflows: ["Test drivers against a matrix of kernels/distros"]
-    types:
-      - completed
+    types: [completed]
+    branches: [main]
       
 permissions:
   contents: read
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   deploy-pages:
-    if: github.event.workflow_run.head_branch == 'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Just discovered https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#limiting-your-workflow-to-run-based-on-branches