### PR TITLE
feat(scap-open): build scap-open + modern-probe on designated hosts

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1,0 +1,10 @@
+- name: Run common tasks to all hosts
+  hosts: all
+  remote_user: "{{ user }}"
+  gather_facts: false
+
+  tasks:
+    - name: Fix the dns issues
+      ansible.builtin.shell: |
+        unlink /etc/resolv.conf && echo 'nameserver 1.1.1.1' > /etc/resolv.conf
+      changed_when: false

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -44,6 +44,12 @@ machines:
   - {name: "oraclelinux-5.15", kernel: "therealbobo/oraclelinux-kernel:5.15-aarch64", rootfs: "therealbobo/oraclelinux-image:5.15-aarch64", arch: "aarch64"}
   - {name: "ubuntu-6.3", kernel: "therealbobo/ubuntu-kernel:6.3-aarch64", rootfs: "therealbobo/ubuntu-image:6.3-aarch64", arch: "aarch64"}
 
+builders:
+  - {name: "centos-builder", kernel: "therealbobo/centos-kernel:5.14-x86_64", rootfs: "therealbobo/builder:0.0.1-x86_64", arch: "x86_64"}
+  - {name: "fedora-builder", kernel: "weaveworks/ignite-kernel:5.14.16", rootfs: "therealbobo/modernprobe-builder:0.0.1-x86_64", arch: "x86_64"}
+  - {name: "centos-builder", kernel: "weaveworks/ignite-kernel:5.14.16", rootfs: "therealbobo/builder:0.0.1-aarch64", arch: "aarch64"}
+  - {name: "fedora-builder", kernel: "weaveworks/ignite-kernel:5.14.16", rootfs: "therealbobo/modernprobe-builder:0.0.1-aarch64", arch: "aarch64"}
+
 output_dir: "~/ansible_output"
 # Number of cpus.
 cpus: 2

--- a/main-playbook.yml
+++ b/main-playbook.yml
@@ -3,6 +3,8 @@
 # Check the specific playbooks and roles to have more information.
 - name: Include bootstrap playbook
   import_playbook: bootstrap.yml
+- name: Include common playbook
+  import_playbook: common.yml
 - name: Include git-repos playbook
   import_playbook: git-repos.yml
 - name: Include scap-open playbook

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -23,7 +23,7 @@
     state: directory
     mode: '0755'
 
-- name: Template the ignite-vm.yaml configuratin file
+- name: Template the ignite-vm.yaml configuratin file for machines
   ansible.builtin.template:
     src: ignite-vm.yaml.j2
     dest: "./roles/bootstrap/files/{{ item.name }}.yaml"
@@ -31,7 +31,16 @@
   loop:
     "{{ machines }}"
   when: item.arch == ansible_facts["architecture"]
+  delegate_to: localhost
 
+- name: Template the ignite-vm.yaml configuratin file for builders
+  ansible.builtin.template:
+    src: ignite-vm.yaml.j2
+    dest: "./roles/bootstrap/files/{{ item.name }}.yaml"
+    mode: '0755'
+  loop:
+    "{{ builders }}"
+  when: item.arch == ansible_facts["architecture"]
   delegate_to: localhost
 
 - name: Pull kernel and rootfs OCI images
@@ -40,14 +49,16 @@
       community.docker.docker_image:
         name: "{{ item.kernel }}"
         source: pull
-      loop: "{{ machines }}"
+        force_source: true
+      loop: "{{ machines | union(builders) }}"
       when: item.arch == ansible_facts["architecture"]
 
     - name: Pull rootfs OCI images
       community.docker.docker_image:
         name: "{{ item.rootfs }}"
         source: pull
-      loop: "{{ machines }}"
+        force_source: true
+      loop: "{{ machines | union(builders) }}"
       when: item.arch == ansible_facts["architecture"]
 
 - name: Create virtual machines run_id={{ run_id }}
@@ -55,7 +66,7 @@
     cmd: ignite run --config "./roles/bootstrap/files/{{ item.name }}.yaml" --runtime docker
   register: ignite_run
   changed_when: ignite_run.rc == 0
-  loop: "{{ machines }}"
+  loop: "{{ machines | union(builders) }}"
   when: item.arch == ansible_facts["architecture"]
   become: true
 
@@ -67,18 +78,28 @@
   until: result.stdout | int == 2
   retries: 5
   delay: 10
-  loop: "{{ machines }}"
+  loop: "{{ machines | union(builders) }}"
   when: item.arch == ansible_facts["architecture"]
   changed_when: result.stdout | int == 2
   become: true
 
-- name: Get IP of the VMs and register them in a variable run_id={{ run_id }}
+- name: Get IP of the VMs(machines) and register them in a variable run_id={{ run_id }}
   ansible.builtin.command:
     cmd: ignite ps -f \{\{.ObjectMeta.Name\}\}={{ item.name }}-{{ run_id }},\{\{.Status.Running\}\}=true -t \{\{.Status.Network.IPAddresses\}\}
   register: machine_ips
   failed_when: machine_ips.stdout_lines | length != 1
   changed_when: machine_ips.stdout_lines | length == 1
   loop: "{{ machines }}"
+  when: item.arch == ansible_facts["architecture"]
+  become: true
+
+- name: Get IP of the VMs(builders) and register them in a variable run_id={{ run_id }}
+  ansible.builtin.command:
+    cmd: ignite ps -f \{\{.ObjectMeta.Name\}\}={{ item.name }}-{{ run_id }},\{\{.Status.Running\}\}=true -t \{\{.Status.Network.IPAddresses\}\}
+  register: builders_ips
+  failed_when: builders_ips.stdout_lines | length != 1
+  changed_when: builders_ips.stdout_lines | length == 1
+  loop: "{{ builders }}"
   when: item.arch == ansible_facts["architecture"]
   become: true
 

--- a/roles/bootstrap/templates/inventory.ini.j2
+++ b/roles/bootstrap/templates/inventory.ini.j2
@@ -5,3 +5,10 @@
 {{ result.item.name }} ansible_host={{ result.stdout }} ansible_ssh_private_key_file={{ prv_key_path }}
 {% endif%}
 {% endfor %}
+
+[builders]
+{% for result in builders_ips.results %}
+{% if "skipped" not in result %}
+{{ result.item.name }} ansible_host={{ result.stdout }} ansible_ssh_private_key_file={{ prv_key_path }}
+{% endif%}
+{% endfor %}

--- a/roles/scap_open/tasks/main.yml
+++ b/roles/scap_open/tasks/main.yml
@@ -14,20 +14,13 @@
         state: directory
         mode: '0755'
 
-
 - name: Prepare the build directory
   block:
-    # TODO: move this elsewhere.
-    - name: Fix the dns issues
-      ansible.builtin.shell: |
-        unlink /etc/resolv.conf && echo 'nameserver 1.1.1.1' > /etc/resolv.conf
-      changed_when: false
-
     - name: Create cmake output dir
       ansible.builtin.file:
         path: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
         state: directory
-        mode: "0755"
+        mode: "0766"
       register: cmake_result
 
     - name: Check btf support
@@ -40,7 +33,7 @@
         cmd: >
              cmake
              -DUSE_BUNDLED_DEPS=ON
-             -DBUILD_LIBSCAP_MODERN_BPF={{ btf_support.stat.exists }}
+             -DBUILD_LIBSCAP_MODERN_BPF=OFF
              -DBUILD_LIBSCAP_GVISOR=OFF
              -DBUILD_BPF=true
              -DCREATE_TEST_TARGETS=OFF
@@ -57,27 +50,6 @@
       ansible.builtin.copy:
         content: "{{ cmake_result | to_nice_json }}"
         dest: "{{ output_dest_dir }}/cmake-build-directory.json"
-        mode: '0755'
-      delegate_to: localhost
-      become: false
-
-- name: Build scap-open binary
-  block:
-    - name: Build scap-open
-      ansible.builtin.command:
-        cmd: make scap-open -j {{ cpus }}
-        chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
-      register: scap_open_result
-      changed_when: false
-  rescue:
-    - name: Print error message to stdout --- build scap-open binary
-      ansible.builtin.debug:
-        var: scap_open_result
-  always:
-    - name: Dump error message to file
-      ansible.builtin.copy:
-        content: "{{ scap_open_result | to_nice_json }}"
-        dest: "{{ output_dest_dir }}/build-scap-open-binary.json"
         mode: '0755'
       delegate_to: localhost
       become: false
@@ -121,7 +93,7 @@
   block:
     - name: Run scap-open with kernel module
       ansible.builtin.command:
-        cmd: ./libscap/examples/01-open/scap-open --num_events 50 --kmod
+        cmd: /tmp/scap-open --num_events 50 --kmod
         chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
       register: result
       changed_when: false
@@ -170,7 +142,7 @@
   block:
     - name: Run scap-open with bpf probe
       ansible.builtin.command:
-        cmd: ./libscap/examples/01-open/scap-open --num_events 50 --bpf driver/bpf/probe.o
+        cmd: /tmp/scap-open --num_events 50 --bpf driver/bpf/probe.o
         chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
       register: result
       changed_when: false
@@ -191,7 +163,7 @@
   block:
     - name: Run scap-open with modern-probe
       ansible.builtin.command:
-        cmd: ./libscap/examples/01-open/scap-open --num_events 50 --modern_bpf
+        cmd: /tmp/scap-open --num_events 50 --modern_bpf
         chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
       register: result
       when: btf_support.stat.exists

--- a/scap-open.yml
+++ b/scap-open.yml
@@ -1,5 +1,104 @@
 # Playbook used to run scap-open-test role.
 # Check the role for more information
+
+- name: Build bpf skeleton on designated builder VM
+  hosts: "fedora-builder"
+  remote_user: "{{ user }}"
+  gather_facts: false
+  tasks:
+    - name: Create cmake output dir
+      ansible.builtin.file:
+        path: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/skeleton-build"
+        state: directory
+        mode: "0755"
+      register: cmake_result
+
+    - name: Prepare cmake for repository
+      ansible.builtin.command:
+        cmd: >
+             cmake
+             -DUSE_BUNDLED_DEPS=ON
+             -DBUILD_LIBSCAP_MODERN_BPF=ON
+             -DBUILD_LIBSCAP_GVISOR=OFF
+             -DCREATE_TEST_TARGETS=OFF
+             ..
+        chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/skeleton-build"
+      changed_when: false
+      register: cmake_result
+
+    - name: Build skeleton
+      ansible.builtin.command:
+        cmd: make ProbeSkeleton -j {{ cpus }}
+        chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/skeleton-build"
+      changed_when: false
+      register: cmake_result
+
+    - name: Fetch the skeleton file
+      ansible.builtin.fetch:
+        src: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/skeleton-build/skel_dir/bpf_probe.skel.h"
+        dest: /tmp/
+        flat: true
+
+- name: Build scap-open on designated builder
+  hosts: "centos-builder"
+  remote_user: "{{ user }}"
+  gather_facts: false
+  tasks:
+    - name: Copy bpf skeleton to centos builder
+      ansible.builtin.copy:
+        src: "/tmp/bpf_probe.skel.h"
+        dest: "/tmp"
+        mode: '0755'
+
+    - name: Create cmake output dir
+      ansible.builtin.file:
+        path: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
+        state: directory
+        mode: "0755"
+      register: cmake_result
+
+    - name: Prepare cmake for repository
+      ansible.builtin.shell:
+        cmd: |
+             source /opt/rh/devtoolset-9/enable &&
+             cmake \
+             -DCMAKE_BUILD_TYPE=Release \
+             -DBUILD_LIBSCAP_MODERN_BPF=ON \
+             -DMODERN_BPF_SKEL_DIR=/tmp \
+             -DBUILD_DRIVER=Off \
+             -DBUILD_BPF=Off \
+             -DBUILD_LIBSCAP_GVISOR=OFF \
+             -DCREATE_TEST_TARGETS=Off \
+             ..
+        chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
+      changed_when: false
+      register: cmake_result
+
+    - name: Build scap-open with modern probe
+      ansible.builtin.shell:
+        cmd: source /opt/rh/devtoolset-9/enable && make scap-open -j {{ cpus }}
+        chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"
+      changed_when: false
+      register: cmake_result
+
+    - name: Fetch the scap-open binary
+      ansible.builtin.fetch:
+        src: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build/libscap/examples/01-open/scap-open"
+        dest: "/tmp/"
+        flat: true
+
+- name: Play that distributes scap-open binary to VMs
+  hosts: "machines"
+  remote_user: "{{ user }}"
+  gather_facts: false
+  tasks:
+    - name: Copy scap-open binary to all VMs
+      ansible.builtin.copy:
+        src: "/tmp/scap-open"
+        dest: "/tmp"
+        mode: '0755'
+      become: false
+
 - name: Play that runs probes tests using scap-open binary
   hosts: all
   gather_facts: false
@@ -8,3 +107,15 @@
   serial: 30
   roles:
     - scap_open
+
+- name: Remove artifacts from localhost
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Remove artifacs
+      ansible.builtin.file:
+        path: "./roles/scap_open/files/"
+        state: absent
+      with_items:
+        - "/tmp/scap-open"
+        - "/tmp/bpf_probe.skel.h"


### PR DESCRIPTION
The scap-open binary and modern-probe are build externally and then pushed to the machines where we want to test them.