### PR TITLE
chore: remove any reference to deprecated gVisor

### DIFF
--- a/ansible-playbooks/group_vars/all/vars.yml
+++ b/ansible-playbooks/group_vars/all/vars.yml
@@ -38,14 +38,14 @@ machines:
   - {name: "oraclelinux-3.10", kernel: "{{ repo }}/oraclelinux-kernel:3.10-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:3.10-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "oraclelinux-4.14", kernel: "{{ repo }}/oraclelinux-kernel:4.14-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:4.14-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "oraclelinux-5.15", kernel: "{{ repo }}/oraclelinux-kernel:5.15-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.15-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
-  - {name: "oraclelinux-5.4", kernel: "{{ repo }}/oraclelinux-kernel:5.4-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.4-x86_64-{{ tag }}", arch: "x86_64", skip_legacy_bpf_tests: true} # noqa: yaml[line-length]
+  - {name: "oraclelinux-5.4", kernel: "{{ repo }}/oraclelinux-kernel:5.4-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.4-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "ubuntu-5.8", kernel: "{{ repo }}/ubuntu-kernel:5.8-x86_64-{{ tag }}", rootfs: "{{ repo }}/ubuntu-image:5.8-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "ubuntu-6.5", kernel: "{{ repo }}/ubuntu-kernel:6.5-x86_64-{{ tag }}", rootfs: "{{ repo }}/ubuntu-image:6.5-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "amazonlinux2022-5.15", kernel: "{{ repo }}/amazonlinux2022-kernel:5.15-aarch64-{{ tag }}", rootfs: "{{ repo }}/amazonlinux2022-image:5.15-aarch64-{{ tag }}", arch: "aarch64"}  # noqa: yaml[line-length]
   - {name: "amazonlinux2-5.4", kernel: "{{ repo }}/amazonlinux2-kernel:5.4-aarch64-{{ tag }}", rootfs: "{{ repo }}/amazonlinux2-image:5.4-aarch64-{{ tag }}", arch: "aarch64"} # noqa: yaml[line-length]
   - {name: "fedora-6.2", kernel: "{{ repo }}/fedora-kernel:6.2-aarch64-{{ tag }}", rootfs: "{{ repo }}/fedora-image:6.2-aarch64-{{ tag }}", arch: "aarch64"} # noqa: yaml[line-length]
   - {name: "oraclelinux-4.14", kernel: "{{ repo }}/oraclelinux-kernel:4.14-aarch64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:4.14-aarch64-{{ tag }}", arch: "aarch64"} # noqa: yaml[line-length]
-  - {name: "oraclelinux-5.15", kernel: "{{ repo }}/oraclelinux-kernel:5.15-aarch64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.15-aarch64-{{ tag }}", arch: "aarch64", skip_legacy_bpf_tests: true} # noqa: yaml[line-length]
+  - {name: "oraclelinux-5.15", kernel: "{{ repo }}/oraclelinux-kernel:5.15-aarch64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.15-aarch64-{{ tag }}", arch: "aarch64"} # noqa: yaml[line-length]
   - {name: "ubuntu-6.5", kernel: "{{ repo }}/ubuntu-kernel:6.5-aarch64-v0.3.2", rootfs: "{{ repo }}/ubuntu-image:6.5-aarch64-v0.3.2", arch: "aarch64"} # noqa: yaml[line-length]
 
 builders:

--- a/ansible-playbooks/roles/scap_open/tasks/main.yml
+++ b/ansible-playbooks/roles/scap_open/tasks/main.yml
@@ -42,7 +42,6 @@
              cmake
              -DUSE_BUNDLED_DEPS=ON
              -DBUILD_LIBSCAP_MODERN_BPF=OFF
-             -DBUILD_LIBSCAP_GVISOR=OFF
              -DCREATE_TEST_TARGETS=OFF
              ..
         chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"

--- a/ansible-playbooks/scap-open.yml
+++ b/ansible-playbooks/scap-open.yml
@@ -19,7 +19,6 @@
              cmake
              -DUSE_BUNDLED_DEPS=ON
              -DBUILD_LIBSCAP_MODERN_BPF=ON
-             -DBUILD_LIBSCAP_GVISOR=OFF
              -DCREATE_TEST_TARGETS=OFF
              ..
         chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/skeleton-build"
@@ -66,7 +65,6 @@
              -DBUILD_LIBSCAP_MODERN_BPF=ON \
              -DMODERN_BPF_SKEL_DIR=/tmp \
              -DBUILD_DRIVER=Off \
-             -DBUILD_LIBSCAP_GVISOR=OFF \
              -DCREATE_TEST_TARGETS=Off \
              ..
         chdir: "{{ remote_repos_folder }}/repos/{{ repos['libs'].name }}/build"


### PR DESCRIPTION
Falco 0.43.0 deprecated gVisor engine. This PR drops any reference to it and removes from `ansible-playbooks/group_vars/all/vars.yml` any reference to `skip_legacy_bpf_tests` (I forgot to remove them in https://github.com/falcosecurity/kernel-testing/pull/113).